### PR TITLE
Raise error on unknown exit code from diff-pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0
+
+## Bug fix
+
+- Fixes an issue where it would appear diff-pdf ran successfully but actually returned an erroneous exit code. Now raises an error if this occurs.
+
 ## 2.0.0
 
 ### Breaking Changes

--- a/lib/pdf_matcher/diff_pdf.rb
+++ b/lib/pdf_matcher/diff_pdf.rb
@@ -19,12 +19,23 @@ module PdfMatcher
       end
     end
 
+    class UnknownDiffPdfExitCode < StandardError
+      def initialize(code)
+        super "pdf_matcher did not recognize the exit code #{code} from the diff-pdf command, " \
+              'this probably means there is a problem with your installed version of diff-pdf.'
+      end
+    end
+
     def initialize
       verify_available!
     end
 
     def exec(pdf1_path, pdf2_path, output_diff: nil, options: nil)
-      system("diff-pdf #{build_options(output_diff, options).join(' ')} #{pdf1_path} #{pdf2_path}")
+      result = system("diff-pdf #{build_options(output_diff, options).join(' ')} #{pdf1_path} #{pdf2_path} > /dev/null 2>&1")
+
+      raise UnknownDiffPdfExitCode.new($?.exitstatus) if $?.exitstatus < 0 || $?.exitstatus > 1
+
+      result
     end
 
     private

--- a/lib/pdf_matcher/version.rb
+++ b/lib/pdf_matcher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PdfMatcher
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/test/pdf_matcher_test.rb
+++ b/test/pdf_matcher_test.rb
@@ -147,4 +147,19 @@ class PdfMatcherTest < TestCase
       PdfMatcher.match?(pdf_data, pdf_data)
     end
   end
+
+  sub_test_case 'exit code' do
+    teardown { PdfMatcher.config.diff_pdf_opts = nil }
+
+    test 'unknown exit code raises exception' do
+      assert_nil PdfMatcher.config.diff_pdf_opts
+
+      PdfMatcher.config.diff_pdf_opts = ['--invalid-option-used-for-testing']
+      pdf_data = create_pdf_data { text 'Hello' }
+
+      assert_raise(PdfMatcher::DiffPdf::UnknownDiffPdfExitCode) do
+        PdfMatcher.match(pdf_data, pdf_data)
+      end
+    end
+  end
 end


### PR DESCRIPTION
**What it does**: Raises an error if the exit code from `diff-pdf`wasn't 0 or 1.

**Why**: This prevents a fail-silent error where it may seem like the pdf's wasn't matching, but there was actually a problem running diff-pdf.

**Background**: When running in Docker, I was troubleshooting why I had a diff, and no diff file was generated, when I discovered that the libraries required to run `diff-pdf` were missing which resulted in an exit code of 127.

**Implemented solution**: Check the exit code, and if it's not 0 or 1, then raise an error.

**Other notes**: I am now redirecting stdout and stderr to /dev/null, as it's unexpected behavior to get stdout spam directly from diff-pdf (and this actually happens in the test case, which is why I discovered it).

I tried to be helpful by adding changelog and version bump, but please let me know if I should change this.

My first Ruby PR ☺️, hope it's useful!

Thanks!